### PR TITLE
Remove Bootstrap CSS link from admin dashboard template

### DIFF
--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -6,7 +6,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Admin Dashboard</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
     <div class="container mt-4">


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove the link to the Bootstrap CSS from the admin dashboard template to improve page load speed and styling consistency.